### PR TITLE
add register script and support operator registry to avs by keystore and password

### DIFF
--- a/l1-contracts/shell-scripts/register/decryptKeystore.js
+++ b/l1-contracts/shell-scripts/register/decryptKeystore.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const { Wallet } = require('ethers');
+
+const args = process.argv.slice(2);
+
+if (args.length < 2) {
+  console.error("Usage: node decryptKeystore.js <keystore-file> <password>");
+  process.exit(1);
+}
+
+const keystorePath = args[0];
+const password = args[1];
+
+try {
+  if (!fs.existsSync(keystorePath)) {
+    throw new Error("Keystore file does not exist");
+  }
+
+  const keystore = fs.readFileSync(keystorePath, 'utf8');
+  const wallet = Wallet.fromEncryptedJsonSync(keystore, password);
+  console.log(wallet.privateKey);
+} catch (error) {
+  console.error("Failed to decrypt keystore:", error.message);
+}

--- a/l1-contracts/shell-scripts/register/register.sh
+++ b/l1-contracts/shell-scripts/register/register.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if [ "$#" -ne 3 ] && [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <keystore-file> <password> <rpc-url> or $0 <private-key> <rpc-url>"
+  exit 1
+fi
+
+if [ "$#" -eq 3 ]; then
+  KEYSTORE_FILE=$1
+  PASSWORD=$2
+  RPC_URL=$3
+  if [ ! -f "$KEYSTORE_FILE" ]; then
+    echo "Keystore file not found: $KEYSTORE_FILE"
+    exit 1
+  fi
+
+  PRIVATE_KEY=$(node decryptKeystore.js "$KEYSTORE_FILE" "$PASSWORD")
+  if [ $? -ne 0 ]; then
+    echo "Failed to execute decryptKeystore.js"
+    exit 1
+  fi
+
+  if [ -z "$PRIVATE_KEY" ]; then
+    echo "Failed to retrieve private key"
+    exit 1
+  fi
+else
+  PRIVATE_KEY=$1
+  RPC_URL=$2
+fi
+
+forge script ../../script/UniFiAVSScripts.sol:UniFiAVSScripts --sig "registerOperatorToUniFiAVS(uint256 signerPk)" $PRIVATE_KEY --private-key $PRIVATE_KEY --rpc-url $RPC_URL --broadcast
+
+# ./register.sh ./test.json 123456 https://rpc.ankr.com/eth [recommended]
+# ./register.sh your_private_key https://rpc.ankr.com/eth [not recommended]

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
     "npm": ">=9.8.0"
   },
   "version": "1.0.0",
-  "description": "Bsed Rollup",
-  "scripts": {
-  },
+  "description": "Based Rollup",
+  "scripts": {},
   "keywords": [
     "ethereum",
     "puffer",
@@ -24,9 +23,15 @@
   "license": "ISC",
   "private": true,
   "workspaces": {
-    "packages": ["l1-contracts", "l2-contracts"],
+    "packages": [
+      "l1-contracts",
+      "l2-contracts"
+    ],
     "nohoist": [
       "**/*"
     ]
+  },
+  "dependencies": {
+    "ethers": "^6.13.2"
   }
 }


### PR DESCRIPTION
1. added register script
2. support operator registry to avs by keystore and password

Since the registerOperatorToUniFiAVS method requires the operator's private key, this is the most cost-effective way to inject the keystore into AVS code, but it does not necessarily represent the best approach

1. `./register.sh keystore.json 123456 https://rpc.ankr.com/eth` [**recommended**]
2. `./register.sh your_private_key https://rpc.ankr.com/eth` [not recommended]